### PR TITLE
Update all paths referring /etc/ to /system/etc/ & add stub media_codecs_ffmpeg.xml

### DIFF
--- a/media/libavextensions/stagefright/AVUtils.cpp
+++ b/media/libavextensions/stagefright/AVUtils.cpp
@@ -456,7 +456,7 @@ void AVUtils::cacheCaptureBuffers(sp<hardware::ICamera> camera, video_encoder en
 }
 
 const char *AVUtils::getCustomCodecsLocation() {
-    return "/etc/media_codecs.xml";
+    return "/system/etc/media_codecs.xml";
 }
 
 #ifdef QCOM_HARDWARE
@@ -483,7 +483,7 @@ void AVUtils::setIntraPeriod(
 #endif
 
 const char *AVUtils::getCustomCodecsPerformanceLocation() {
-    return "/etc/media_codecs_performance.xml";
+    return "/system/etc/media_codecs_performance.xml";
 }
 
 bool AVUtils::IsHevcIDR(const sp<ABuffer> &) {

--- a/media/libmedia/MediaProfiles.cpp
+++ b/media/libmedia/MediaProfiles.cpp
@@ -609,7 +609,7 @@ MediaProfiles::getInstance()
     if (!sIsInitialized) {
         char value[PROPERTY_VALUE_MAX];
         if (property_get("media.settings.xml", value, NULL) <= 0) {
-            const char *defaultXmlFile = "/etc/media_profiles.xml";
+            const char *defaultXmlFile = "/system/etc/media_profiles.xml";
             FILE *fp = fopen(defaultXmlFile, "r");
             if (fp == NULL) {
                 ALOGW("could not find media config xml file");

--- a/media/libstagefright/data/Android.mk
+++ b/media/libstagefright/data/Android.mk
@@ -1,0 +1,28 @@
+# I'm lazy, so I copy this from external/stagefright-plugins -- peat-psuwit
+#
+# Copyright (C) 2015 The CyanogenMod Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE        := media_codecs_ffmpeg.xml
+LOCAL_MODULE_TAGS   := optional
+LOCAL_MODULE_CLASS  := ETC
+LOCAL_SRC_FILES     := media_codecs_ffmpeg.xml
+include $(BUILD_PREBUILT)
+
+# Every other files in this directory will be copied using PRODUCT_COPY_FILES
+# for each device as needed.

--- a/media/libstagefright/data/media_codecs_ffmpeg.xml
+++ b/media/libstagefright/data/media_codecs_ffmpeg.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<!-- Stub media_codecs_ffmpeg.xml to be included by devices' media_codecs.xml
+
+     This file is normally provided by external/stagefright-plugins, but
+     Halium doesn't build this library. It doesn't make much sense to build
+     it because we already have media frameworks available in the host
+     environment. However, many devices have its media_codecs.xml include
+     this file. Without this file, the whole codec listing process fails.
+     Thus, to avoid fixing potentially tens of device trees, this file is
+     provided.
+-->
+
+<Included>
+    <!-- Nothing! -->
+</Included>

--- a/services/audiopolicy/engineconfigurable/wrapper/ParameterManagerWrapper.cpp
+++ b/services/audiopolicy/engineconfigurable/wrapper/ParameterManagerWrapper.cpp
@@ -64,7 +64,7 @@ using utilities::convertTo;
 namespace audio_policy
 {
 const char *const ParameterManagerWrapper::mPolicyPfwDefaultConfFileName =
-    "/etc/parameter-framework/ParameterFrameworkConfigurationPolicy.xml";
+    "/system/etc/parameter-framework/ParameterFrameworkConfigurationPolicy.xml";
 
 template <>
 struct ParameterManagerWrapper::parameterManagerElementSupported<ISelectionCriterionInterface> {};


### PR DESCRIPTION
These 2 commits allow successful media decoding with gst-droid on FP2. Only HW decoding is tested. Haven't tested the actual output yet. [1]

The first commit update paths to /etc/* to /system/etc/\*. This way, if the codec list is initialized outside the container, there will be no need to create symlinks to various media_codecs\*.xml files.

The second commit creates a stub media_codecs_ffmpeg.xml file. This file is included from various devices' media_codecs.xml. To reduce the need for device tree modification, I decided to add a stub here.

The video decoding works with or without PR #3 (local codec PR).

[1] At least the following command works:
```
GST_DEBUG=3 gst-launch-1.0 filesrc location=./big_buck_bunny_720p_1mb.mp4 ! qtdemux ! h264parse ! droidvdec ! fakesink
```