### PR TITLE
Disable cameraserver and mediaserver

### DIFF
--- a/camera/cameraserver/cameraserver.rc
+++ b/camera/cameraserver/cameraserver.rc
@@ -4,3 +4,4 @@ service cameraserver /system/bin/cameraserver
     group audio camera input drmrpc
     ioprio rt 4
     writepid /dev/cpuset/camera-daemon/tasks /dev/stune/top-app/tasks
+    disabled

--- a/media/mediaserver/mediaserver.rc
+++ b/media/mediaserver/mediaserver.rc
@@ -4,3 +4,4 @@ service media /system/bin/mediaserver
     group audio camera inet net_bt net_bt_admin net_bw_acct drmrpc mediadrm
     ioprio rt 4
     writepid /dev/cpuset/foreground/tasks /dev/stune/foreground/tasks
+    disabled


### PR DESCRIPTION
CameraService, MediaPlayerService and ResourceManagerService are already
instantiated by droidmedia.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>
Change-Id: I53d35ee2f38d1db9c85cec2809ca5515ab0e4b9d